### PR TITLE
v1-test-sender

### DIFF
--- a/docker-compose/app/docker-compose.yml
+++ b/docker-compose/app/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       REDIS_DSN: redis:6379
       SENDER_EMAIL: ivan.frontoff42@gmail.com
       SENDER_PASSWORD: "ahlb bhnf zvsl pxya"
-      APP_URL: "http://localhost"
+      SENDER_MODE: "test"
+      DOMAIN: "http://localhost:8080"
     ports:
       - "8081:8081"
     restart: always

--- a/docker-compose/deploy/docker-compose.yml
+++ b/docker-compose/deploy/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       SENDER_MODE: "api"
       SENDER_API_KEY: ${SENDER_API_KEY}
       SENDER_EMAIL: ${SENDER_EMAIL}
+      DOMAIN: https://${DOMAIN}
     restart: always
     depends_on:
       postgres:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,7 @@ func InitConfig() *Config {
 	flag.StringVar(&senderEmail, "se", defaultSenderEmail, "sender email")
 	flag.StringVar(&senderPassword, "sp", defaultSenderPassword, "sender password")
 	flag.StringVar(&senderApiKey, "sk", defaultSenderApiKey, "sender api key")
-	flag.StringVar(&domain, "url", defaultDomain, "http://localhost")
+	flag.StringVar(&domain, "url", defaultDomain, "domain")
 
 	flag.Parse()
 

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -16,7 +16,7 @@ var (
 	defaultRedisDSN      = "localhost:6379"
 	defaultRedisPassword = ""
 	defaultRedisDB       = 0
-	defaultDomain        = "http://localhost"
+	defaultDomain        = "http://localhost:8080"
 
 	defaultSenderMode     = "smtp"
 	defaultSenderEmail    = "ivan.frontoff42@gmail.com"

--- a/internal/pkg/doar/doar.go
+++ b/internal/pkg/doar/doar.go
@@ -8,6 +8,7 @@ import (
 	"github.com/training-of-new-employees/qon/internal/logger"
 	apisender "github.com/training-of-new-employees/qon/internal/pkg/doar/api-sender"
 	smtpsender "github.com/training-of-new-employees/qon/internal/pkg/doar/smtp-sender"
+	testsender "github.com/training-of-new-employees/qon/internal/pkg/doar/test-sender"
 )
 
 // Интерфейс EmailSender.
@@ -15,6 +16,7 @@ type EmailSender interface {
 	SendCode(email string, code string) error
 	InviteUser(email string, invitationLink string) error
 	SendPassword(email string, password string) error
+	Mode() string
 }
 
 type Mailer interface {
@@ -25,6 +27,7 @@ type Mailer interface {
 type Sender struct {
 	mailer      Mailer
 	ClientEmail string
+	mode        string
 }
 
 // NewSender - конструктор Sender.
@@ -37,13 +40,17 @@ func NewSender(mode string, config *config.Config) *Sender {
 	if mode == "api" {
 		sender = apisender.NewApiSender(config.SenderEmail, config.SenderApiKey)
 	}
+	if mode == "test" {
+		sender = testsender.NewTestSender()
+	}
 
 	return &Sender{
 		mailer: sender,
+		mode:   mode,
 	}
 }
 
-// SendCode отправляет код верификации.
+// SendCode - отправка кода верификации.
 func (s *Sender) SendCode(email string, code string) error {
 	title := "Подтверждение регистрации (QuickOn)"
 	body := fmt.Sprintf("Код верификации: %s", code)
@@ -55,7 +62,7 @@ func (s *Sender) SendCode(email string, code string) error {
 	return nil
 }
 
-// SendCode отправляет пригласительную ссылку.
+// SendCode - отправка пригласительной ссылки.
 func (s *Sender) InviteUser(email string, invitationLink string) error {
 	title := "Пригласительная ссылка (QuickOn)"
 	body := fmt.Sprintf("Пригласительная cсылка: %s", invitationLink)
@@ -67,7 +74,7 @@ func (s *Sender) InviteUser(email string, invitationLink string) error {
 	return nil
 }
 
-// SendCode отправляет новый пароль.
+// SendCode - отправка нового пароля.
 func (s *Sender) SendPassword(email string, password string) error {
 	title := "Новый пароль (QuickOn)"
 	body := fmt.Sprintf("пароль: %s", password)
@@ -77,4 +84,9 @@ func (s *Sender) SendPassword(email string, password string) error {
 	}
 
 	return nil
+}
+
+// Mode - чтобы узнать, как отправляются письма.
+func (s *Sender) Mode() string {
+	return s.mode
 }

--- a/internal/pkg/doar/test-sender/test-sender.go
+++ b/internal/pkg/doar/test-sender/test-sender.go
@@ -5,15 +5,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/training-of-new-employees/qon/internal/errs"
 )
 
 // TestSender - test-sender.
 type TestSender struct {
-	senderEmail string
-	apiKey      string
-	client      *resty.Client
 }
 
 // NewTestSender - конструктор.

--- a/internal/pkg/doar/test-sender/test-sender.go
+++ b/internal/pkg/doar/test-sender/test-sender.go
@@ -2,7 +2,6 @@
 package testsender
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/training-of-new-employees/qon/internal/errs"
@@ -19,7 +18,7 @@ func NewTestSender() *TestSender {
 
 // SendEmail - вывод содержания письма пользователю.
 func (s *TestSender) SendEmail(email string, title string, body string) error {
-	errs.ErrNotSendEmail = errors.New(fmt.Sprintf("email: %s; subject: %s; body: %s", email, title, body))
+	errs.ErrNotSendEmail = fmt.Errorf("email: %s; subject: %s; body: %s", email, title, body)
 
 	return errs.ErrNotSendEmail
 }

--- a/internal/pkg/doar/test-sender/test-sender.go
+++ b/internal/pkg/doar/test-sender/test-sender.go
@@ -1,0 +1,29 @@
+// Package test-sender - пакет для мок-рассылки писем.
+package testsender
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/training-of-new-employees/qon/internal/errs"
+)
+
+// TestSender - test-sender.
+type TestSender struct {
+	senderEmail string
+	apiKey      string
+	client      *resty.Client
+}
+
+// NewTestSender - конструктор.
+func NewTestSender() *TestSender {
+	return &TestSender{}
+}
+
+// SendEmail - вывод содержания письма пользователю.
+func (s *TestSender) SendEmail(email string, title string, body string) error {
+	errs.ErrNotSendEmail = errors.New(fmt.Sprintf("email: %s; subject: %s; body: %s", email, title, body))
+
+	return errs.ErrNotSendEmail
+}

--- a/internal/service/impl/user_service.go
+++ b/internal/service/impl/user_service.go
@@ -202,6 +202,11 @@ func (u *uService) CreateUser(ctx context.Context, val model.UserCreate) (*model
 	// Отправление пригласительной ссылки сотруднику
 	if err = u.sender.InviteUser(val.Email, link); err != nil {
 		logger.Log.Warn(fmt.Sprintf("Не удалось отправить пригласительную ссылку сотруднику с емейлом %s", val.Email))
+
+		// режим мок-рассылки писем, при котором содержание письма выводится в теле пользователю
+		if u.sender.Mode() == "test" {
+			return nil, errs.ErrNotSendEmail
+		}
 	}
 
 	return createdUser, nil

--- a/internal/service/impl/user_service_test.go
+++ b/internal/service/impl/user_service_test.go
@@ -844,6 +844,7 @@ func Test_uService_CreateUser(t *testing.T) {
 				f.userdb.EXPECT().CreateUser(nil, gomock.Any()).Return(u, nil)
 				f.sender.EXPECT().InviteUser(u.Email, gomock.Any()).Return(errs.ErrInternal)
 				f.cache.EXPECT().SetInviteCode(nil, gomock.Any(), gomock.Any()).Return(errs.ErrInternal)
+				f.sender.EXPECT().Mode().Return("api")
 			},
 			args{
 				nil,

--- a/mocks/pkg/doar/doar.go
+++ b/mocks/pkg/doar/doar.go
@@ -52,6 +52,20 @@ func (mr *MockEmailSenderMockRecorder) InviteUser(email, invitationLink any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InviteUser", reflect.TypeOf((*MockEmailSender)(nil).InviteUser), email, invitationLink)
 }
 
+// Mode mocks base method.
+func (m *MockEmailSender) Mode() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Mode")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Mode indicates an expected call of Mode.
+func (mr *MockEmailSenderMockRecorder) Mode() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mode", reflect.TypeOf((*MockEmailSender)(nil).Mode))
+}
+
 // SendCode mocks base method.
 func (m *MockEmailSender) SendCode(email, code string) error {
 	m.ctrl.T.Helper()

--- a/mocks/service/user_service.go
+++ b/mocks/service/user_service.go
@@ -108,7 +108,7 @@ func (m *MockServiceUser) EditAdmin(ctx context.Context, val model.AdminEdit) (*
 }
 
 // EditAdmin indicates an expected call of EditAdmin.
-func (mr *MockServiceUserMockRecorder) EditAdmin(ctx, val interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) EditAdmin(ctx, val any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EditAdmin", reflect.TypeOf((*MockServiceUser)(nil).EditAdmin), ctx, val)
 }
@@ -123,7 +123,7 @@ func (m *MockServiceUser) EditUser(ctx context.Context, val *model.UserEdit, edi
 }
 
 // EditUser indicates an expected call of EditUser.
-func (mr *MockServiceUserMockRecorder) EditUser(ctx, val, editorCompanyID interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) EditUser(ctx, val, editorCompanyID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EditUser", reflect.TypeOf((*MockServiceUser)(nil).EditUser), ctx, val, editorCompanyID)
 }
@@ -138,7 +138,7 @@ func (m *MockServiceUser) GenerateInvitationLinkUser(ctx context.Context, email 
 }
 
 // GenerateInvitationLinkUser indicates an expected call of GenerateInvitationLinkUser.
-func (mr *MockServiceUserMockRecorder) GenerateInvitationLinkUser(ctx, email interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) GenerateInvitationLinkUser(ctx, email any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateInvitationLinkUser", reflect.TypeOf((*MockServiceUser)(nil).GenerateInvitationLinkUser), ctx, email)
 }
@@ -153,7 +153,7 @@ func (m *MockServiceUser) GenerateTokenPair(ctx context.Context, userId int, isA
 }
 
 // GenerateTokenPair indicates an expected call of GenerateTokenPair.
-func (mr *MockServiceUserMockRecorder) GenerateTokenPair(ctx, userId, isAdmin, companyID interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) GenerateTokenPair(ctx, userId, isAdmin, companyID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTokenPair", reflect.TypeOf((*MockServiceUser)(nil).GenerateTokenPair), ctx, userId, isAdmin, companyID)
 }
@@ -168,7 +168,7 @@ func (m *MockServiceUser) GetAdminFromCache(arg0 context.Context, arg1 string) (
 }
 
 // GetAdminFromCache indicates an expected call of GetAdminFromCache.
-func (mr *MockServiceUserMockRecorder) GetAdminFromCache(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) GetAdminFromCache(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdminFromCache", reflect.TypeOf((*MockServiceUser)(nil).GetAdminFromCache), arg0, arg1)
 }
@@ -183,7 +183,7 @@ func (m *MockServiceUser) GetUserByEmail(ctx context.Context, email string) (*mo
 }
 
 // GetUserByEmail indicates an expected call of GetUserByEmail.
-func (mr *MockServiceUserMockRecorder) GetUserByEmail(ctx, email interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) GetUserByEmail(ctx, email any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByEmail", reflect.TypeOf((*MockServiceUser)(nil).GetUserByEmail), ctx, email)
 }
@@ -198,7 +198,7 @@ func (m *MockServiceUser) GetUserByID(ctx context.Context, id int) (*model.UserI
 }
 
 // GetUserByID indicates an expected call of GetUserByID.
-func (mr *MockServiceUserMockRecorder) GetUserByID(ctx, id interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) GetUserByID(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByID", reflect.TypeOf((*MockServiceUser)(nil).GetUserByID), ctx, id)
 }
@@ -213,7 +213,7 @@ func (m *MockServiceUser) GetUserInviteCodeFromCache(ctx context.Context, email 
 }
 
 // GetUserInviteCodeFromCache indicates an expected call of GetUserInviteCodeFromCache.
-func (mr *MockServiceUserMockRecorder) GetUserInviteCodeFromCache(ctx, email interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) GetUserInviteCodeFromCache(ctx, email any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserInviteCodeFromCache", reflect.TypeOf((*MockServiceUser)(nil).GetUserInviteCodeFromCache), ctx, email)
 }
@@ -228,7 +228,7 @@ func (m *MockServiceUser) GetUsersByCompany(ctx context.Context, companyID int) 
 }
 
 // GetUsersByCompany indicates an expected call of GetUsersByCompany.
-func (mr *MockServiceUserMockRecorder) GetUsersByCompany(ctx, companyID interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) GetUsersByCompany(ctx, companyID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersByCompany", reflect.TypeOf((*MockServiceUser)(nil).GetUsersByCompany), ctx, companyID)
 }
@@ -242,7 +242,7 @@ func (m *MockServiceUser) ResetPassword(ctx context.Context, email string) error
 }
 
 // ResetPassword indicates an expected call of ResetPassword.
-func (mr *MockServiceUserMockRecorder) ResetPassword(ctx, email interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) ResetPassword(ctx, email any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetPassword", reflect.TypeOf((*MockServiceUser)(nil).ResetPassword), ctx, email)
 }
@@ -256,7 +256,7 @@ func (m *MockServiceUser) UpdatePasswordAndActivateUser(ctx context.Context, ema
 }
 
 // UpdatePasswordAndActivateUser indicates an expected call of UpdatePasswordAndActivateUser.
-func (mr *MockServiceUserMockRecorder) UpdatePasswordAndActivateUser(ctx, email, password interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) UpdatePasswordAndActivateUser(ctx, email, password any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePasswordAndActivateUser", reflect.TypeOf((*MockServiceUser)(nil).UpdatePasswordAndActivateUser), ctx, email, password)
 }
@@ -271,7 +271,7 @@ func (m *MockServiceUser) WriteAdminToCache(ctx context.Context, admin model.Cre
 }
 
 // WriteAdminToCache indicates an expected call of WriteAdminToCache.
-func (mr *MockServiceUserMockRecorder) WriteAdminToCache(ctx, admin interface{}) *gomock.Call {
+func (mr *MockServiceUserMockRecorder) WriteAdminToCache(ctx, admin any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAdminToCache", reflect.TypeOf((*MockServiceUser)(nil).WriteAdminToCache), ctx, admin)
 }

--- a/mocks/store/cache/interface.go
+++ b/mocks/store/cache/interface.go
@@ -79,7 +79,7 @@ func (m *MockCache) GetInviteCode(ctx context.Context, key string) (string, erro
 }
 
 // GetInviteCode indicates an expected call of GetInviteCode.
-func (mr *MockCacheMockRecorder) GetInviteCode(ctx, key interface{}) *gomock.Call {
+func (mr *MockCacheMockRecorder) GetInviteCode(ctx, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInviteCode", reflect.TypeOf((*MockCache)(nil).GetInviteCode), ctx, key)
 }
@@ -107,7 +107,7 @@ func (m *MockCache) SetInviteCode(ctx context.Context, key, code string) error {
 }
 
 // SetInviteCode indicates an expected call of SetInviteCode.
-func (mr *MockCacheMockRecorder) SetInviteCode(ctx, key, code interface{}) *gomock.Call {
+func (mr *MockCacheMockRecorder) SetInviteCode(ctx, key, code any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInviteCode", reflect.TypeOf((*MockCache)(nil).SetInviteCode), ctx, key, code)
 }

--- a/mocks/store/position_repo.go
+++ b/mocks/store/position_repo.go
@@ -115,16 +115,16 @@ func (mr *MockRepositoryPositionMockRecorder) GetPositionsDB(ctx, companyID any)
 }
 
 // UpdatePositionDB mocks base method.
-func (m *MockRepositoryPosition) UpdatePositionDB(ctx context.Context, id int, position model.PositionSet) (*model.Position, error) {
+func (m *MockRepositoryPosition) UpdatePositionDB(ctx context.Context, positionID int, position model.PositionSet) (*model.Position, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePositionDB", ctx, id, position)
+	ret := m.ctrl.Call(m, "UpdatePositionDB", ctx, positionID, position)
 	ret0, _ := ret[0].(*model.Position)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdatePositionDB indicates an expected call of UpdatePositionDB.
-func (mr *MockRepositoryPositionMockRecorder) UpdatePositionDB(ctx, id, position any) *gomock.Call {
+func (mr *MockRepositoryPositionMockRecorder) UpdatePositionDB(ctx, positionID, position any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePositionDB", reflect.TypeOf((*MockRepositoryPosition)(nil).UpdatePositionDB), ctx, id, position)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePositionDB", reflect.TypeOf((*MockRepositoryPosition)(nil).UpdatePositionDB), ctx, positionID, position)
 }

--- a/mocks/store/user_repo.go
+++ b/mocks/store/user_repo.go
@@ -41,48 +41,48 @@ func (m *MockRepositoryUser) EXPECT() *MockRepositoryUserMockRecorder {
 }
 
 // CreateAdmin mocks base method.
-func (m *MockRepositoryUser) CreateAdmin(arg0 context.Context, arg1 model.UserCreate, arg2 string) (*model.User, error) {
+func (m *MockRepositoryUser) CreateAdmin(ctx context.Context, admin model.UserCreate, companyName string) (*model.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAdmin", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateAdmin", ctx, admin, companyName)
 	ret0, _ := ret[0].(*model.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAdmin indicates an expected call of CreateAdmin.
-func (mr *MockRepositoryUserMockRecorder) CreateAdmin(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockRepositoryUserMockRecorder) CreateAdmin(ctx, admin, companyName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAdmin", reflect.TypeOf((*MockRepositoryUser)(nil).CreateAdmin), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAdmin", reflect.TypeOf((*MockRepositoryUser)(nil).CreateAdmin), ctx, admin, companyName)
 }
 
 // CreateUser mocks base method.
-func (m *MockRepositoryUser) CreateUser(arg0 context.Context, arg1 model.UserCreate) (*model.User, error) {
+func (m *MockRepositoryUser) CreateUser(ctx context.Context, user model.UserCreate) (*model.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUser", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateUser", ctx, user)
 	ret0, _ := ret[0].(*model.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateUser indicates an expected call of CreateUser.
-func (mr *MockRepositoryUserMockRecorder) CreateUser(arg0, arg1 any) *gomock.Call {
+func (mr *MockRepositoryUserMockRecorder) CreateUser(ctx, user any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockRepositoryUser)(nil).CreateUser), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockRepositoryUser)(nil).CreateUser), ctx, user)
 }
 
 // EditAdmin mocks base method.
-func (m *MockRepositoryUser) EditAdmin(arg0 context.Context, arg1 model.AdminEdit) (*model.AdminEdit, error) {
+func (m *MockRepositoryUser) EditAdmin(ctx context.Context, edit model.AdminEdit) (*model.AdminEdit, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EditAdmin", arg0, arg1)
+	ret := m.ctrl.Call(m, "EditAdmin", ctx, edit)
 	ret0, _ := ret[0].(*model.AdminEdit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EditAdmin indicates an expected call of EditAdmin.
-func (mr *MockRepositoryUserMockRecorder) EditAdmin(arg0, arg1 any) *gomock.Call {
+func (mr *MockRepositoryUserMockRecorder) EditAdmin(ctx, edit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EditAdmin", reflect.TypeOf((*MockRepositoryUser)(nil).EditAdmin), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EditAdmin", reflect.TypeOf((*MockRepositoryUser)(nil).EditAdmin), ctx, edit)
 }
 
 // EditUser mocks base method.
@@ -101,18 +101,18 @@ func (mr *MockRepositoryUserMockRecorder) EditUser(ctx, edit any) *gomock.Call {
 }
 
 // GetUserByEmail mocks base method.
-func (m *MockRepositoryUser) GetUserByEmail(arg0 context.Context, arg1 string) (*model.User, error) {
+func (m *MockRepositoryUser) GetUserByEmail(ctx context.Context, email string) (*model.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserByEmail", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetUserByEmail", ctx, email)
 	ret0, _ := ret[0].(*model.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserByEmail indicates an expected call of GetUserByEmail.
-func (mr *MockRepositoryUserMockRecorder) GetUserByEmail(arg0, arg1 any) *gomock.Call {
+func (mr *MockRepositoryUserMockRecorder) GetUserByEmail(ctx, email any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByEmail", reflect.TypeOf((*MockRepositoryUser)(nil).GetUserByEmail), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByEmail", reflect.TypeOf((*MockRepositoryUser)(nil).GetUserByEmail), ctx, email)
 }
 
 // GetUserByID mocks base method.


### PR DESCRIPTION
Добавлена mock-рассылка писем, которая позволяют имитировать отправку писем. Необходима для тестирования и отладки кода, связанного с электронной почтой.